### PR TITLE
Allow for RegEx over files & Update label

### DIFF
--- a/src/main/java/com/pandora/plugin/actions/SearchAndConvertFilesToKotlinWithHistory.kt
+++ b/src/main/java/com/pandora/plugin/actions/SearchAndConvertFilesToKotlinWithHistory.kt
@@ -93,7 +93,7 @@ class SearchAndConvertFilesToKotlinWithHistory : AnAction() {
 
     private fun regexVerify(projectBase: VirtualFile, regex: String?): Array<VirtualFile>? {
         if (regex == null) return null
-        val r = Regex.fromLiteral(regex)
+        val r = Regex(regex)
         return findMatchingChildren(projectBase) { file -> r.containsMatchIn(file.name) }
     }
 

--- a/src/main/java/com/pandora/plugin/ui/FileSearchDialog.kt
+++ b/src/main/java/com/pandora/plugin/ui/FileSearchDialog.kt
@@ -16,25 +16,17 @@
 package com.pandora.plugin.ui
 
 import com.intellij.openapi.project.Project
-import com.intellij.openapi.ui.*
+import com.intellij.openapi.ui.ComboBox
+import com.intellij.openapi.ui.DialogWrapper
+import com.intellij.openapi.ui.MultiLineLabelUI
+import com.intellij.openapi.ui.VerticalFlowLayout
 import com.intellij.openapi.util.SystemInfo
 import com.pandora.plugin.options.IntComparison
 import com.pandora.plugin.options.PanelOption
 import com.pandora.plugin.options.SearchOptions
 import org.jetbrains.annotations.Nls
-import org.jetbrains.annotations.NonNls
-import java.awt.Dimension
-import java.awt.FlowLayout
 import java.awt.GridBagLayout
-import java.awt.event.KeyEvent
-import java.awt.event.KeyListener
 import javax.swing.*
-import javax.swing.text.DocumentFilter
-import javax.swing.text.PlainDocument
-import javax.swing.text.NumberFormatter
-import java.text.NumberFormat
-
-
 
 class FileSearchDialog(project: Project,
                        private val message: String,
@@ -73,7 +65,7 @@ class FileSearchDialog(project: Project,
 
     private fun createTextComponent(str: String): JComponent {
         val textLabel = JLabel(str)
-        textLabel.ui = MultiLineLabelUI()
+        textLabel.setUI(MultiLineLabelUI())
         textLabel.border = BorderFactory.createEmptyBorder(0, 0, 5, 0)
         return textLabel
     }
@@ -84,7 +76,7 @@ class FileSearchDialog(project: Project,
         messagePanel.add(createTextComponent(message))
         val regexPanel = JPanel(GridBagLayout())
         regexCheckBox = JCheckBox()
-        regexCheckBox.text = "Regex"
+        regexCheckBox.text = "Regex (extensions allowed, not full filepath)"
         regexCheckBox.isSelected = lastRegexUsed
         regexCheckBox.isEnabled = true
         regexPanel.add(regexCheckBox, PanelOption.WRAP.constraints)


### PR DESCRIPTION
The old Regex.fromLiteral does not actually run a RegEx, it simply searches for the literal string provided. See documentation: https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.text/-regex/from-literal.html

By updating the creation of the RegEx object we enable the user to search their codebase using regular expressions. Also update the label for the regex field as suggested in #5.

This PR closes #5.